### PR TITLE
Single-layer team smell and refactoring

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -46,7 +46,7 @@
         "@types/jointjs": "^2.0.0",
         "@types/jquery": "^3.3.30",
         "@types/lodash": "^4.14.135",
-        "@types/node": "~8.9.4",
+        "@types/node": "^20.8.7",
         "codelyzer": "~6.0.2",
         "jasmine-core": "~2.99.1",
         "jasmine-spec-reporter": "~4.2.1",
@@ -3500,8 +3500,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "8.9.5",
-      "license": "MIT"
+      "version": "20.8.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
+      "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -6026,11 +6030,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/engine.io/node_modules/@types/node": {
-      "version": "20.6.1",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/engine.io/node_modules/debug": {
       "version": "4.3.4",
@@ -12321,6 +12320,11 @@
       "version": "1.9.1",
       "license": "MIT"
     },
+    "node_modules/undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA=="
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "license": "MIT",
@@ -15231,7 +15235,12 @@
       "version": "1.3.2"
     },
     "@types/node": {
-      "version": "8.9.5"
+      "version": "20.8.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
+      "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
+      "requires": {
+        "undici-types": "~5.25.1"
+      }
     },
     "@types/parse-json": {
       "version": "4.0.0"
@@ -16888,10 +16897,6 @@
         "ws": "~8.11.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "20.6.1",
-          "devOptional": true
-        },
         "debug": {
           "version": "4.3.4",
           "devOptional": true,
@@ -20827,6 +20832,11 @@
     },
     "underscore": {
       "version": "1.9.1"
+    },
+    "undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -49,7 +49,7 @@
     "@types/jointjs": "^2.0.0",
     "@types/jquery": "^3.3.30",
     "@types/lodash": "^4.14.135",
-    "@types/node": "~8.9.4",
+    "@types/node": "^20.8.7",
     "codelyzer": "~6.0.2",
     "jasmine-core": "~2.99.1",
     "jasmine-spec-reporter": "~4.2.1",

--- a/client/src/app/architecture/architecture-editing/architecture-editing.service.ts
+++ b/client/src/app/architecture/architecture-editing/architecture-editing.service.ts
@@ -1,14 +1,14 @@
 import { Injectable } from '@angular/core';
-import { AddDatastoreCommand, AddMessageBrokerCommand, AddMessageRouterCommand, AddServiceCommand, NodeCommand, RemoveCommunicationPatternCommand, RemoveDatastoreCommand, RemoveNodeCommand, RemoveServiceCommand } from '../../commands/node-commands';
+import { AddDatastoreCommand, AddMessageBrokerCommand, AddMessageRouterCommand, AddServiceCommand, NodeCommand, RemoveCommunicationPatternCommand, RemoveDatastoreCommand, RemoveNodeCommand, RemoveServiceCommand } from '../node-commands';
 import { MessageService } from 'primeng/api';
 import { GraphInvoker } from '../../commands/invoker';
 import { GraphService } from '../../graph/graph.service';
 
 import { g } from 'jointjs';
-import { AddLinkCommand, RemoveLinkCommand } from '../../commands/link-commands';
+import { AddLinkCommand, RemoveLinkCommand } from '../link-commands';
 import { EditorNavigationService } from '../../editor/navigation/navigation.service';
 import { ToolSelectionService } from 'src/app/editor/tool-selection/tool-selection.service';
-import { AddMemberToTeamGroupCommand } from 'src/app/commands/team-commands';
+import { AddMemberToTeamGroupCommand } from 'src/app/teams/team-commands';
 
 @Injectable({
   providedIn: 'root'

--- a/client/src/app/architecture/link-commands.ts
+++ b/client/src/app/architecture/link-commands.ts
@@ -45,6 +45,7 @@ export class RemoveLinkCommand implements Command {
     t: boolean;
     cb:boolean;
     sd:boolean;
+    removedLink: joint.shapes.microtosca.RunTimeLink;
 
     constructor(graph: Graph, link: joint.shapes.microtosca.RunTimeLink) {
         this.graph = graph;
@@ -59,12 +60,10 @@ export class RemoveLinkCommand implements Command {
     }
 
     execute() {
-        this.link.remove();
+        this.removedLink = this.link.remove();
     }
 
     unexecute() {
-        var source = this.graph.getNode(this.source_name);
-        var target = this.graph.getNode(this.target_name);
-        this.graph.addRunTimeInteraction(source, target, this.t, this.cb, this.sd);
+        this.removedLink.addTo(this.graph);
     }
 }

--- a/client/src/app/architecture/link-commands.ts
+++ b/client/src/app/architecture/link-commands.ts
@@ -1,4 +1,4 @@
-import { Command } from './icommand';
+import { Command } from '../commands/icommand';
 import * as joint from 'jointjs';
 import { Graph } from "../graph/model/graph";
 

--- a/client/src/app/architecture/node-commands.ts
+++ b/client/src/app/architecture/node-commands.ts
@@ -1,53 +1,12 @@
-import { Command, Sequentiable } from '../commands/icommand';
+import { Command, ElementCommand, Sequentiable } from '../commands/icommand';
 import * as joint from 'jointjs';
 import { g } from 'jointjs';
 import { Graph } from "../graph/model/graph";
 
 
-export abstract class NodeCommand<T extends joint.shapes.microtosca.Node> implements Command {
-    
-    abstract execute();
-    abstract unexecute();
 
-    protected node: T;
 
-    setNode(node: T) {
-        this.node = node;
-    }
-
-    getNode(): T {
-        return this.node;
-    }
-
-    constructor(node?: T) {
-        this.node = node;
-    }
-
-    then<U extends Command>(next: U): Sequentiable<U> {
-        let action = () => {this.execute()};
-        let revert = () => {this.unexecute()};
-        let getNode = () => { return this.getNode() };
-
-        let newCommand = Sequentiable.of(next);
-
-        newCommand.execute = () => {
-            action();
-            let node = getNode();
-            console.debug("next", next);
-            console.debug("next instanceof NodeCommand?", next instanceof NodeCommand);
-            if(next instanceof NodeCommand)
-                next.setNode(node);
-            next.execute();
-        }
-        newCommand.unexecute = () => {
-            next.unexecute();
-            revert();
-        }
-        return newCommand;
-    };
-
-}
-
+export abstract class NodeCommand<T extends joint.shapes.microtosca.Node> extends ElementCommand<T> {}
 
 abstract class NodeGeneratorCommand<T extends joint.shapes.microtosca.Node> extends NodeCommand<T> {
 
@@ -63,11 +22,11 @@ abstract class NodeGeneratorCommand<T extends joint.shapes.microtosca.Node> exte
     protected abstract generateNode(): T;
 
     execute() {
-        this.node = this.generateNode();
+        this.set(this.generateNode());
     }
 
     unexecute() {
-        this.node.remove();
+        this.get().remove();
     }
 }
 

--- a/client/src/app/architecture/node-commands.ts
+++ b/client/src/app/architecture/node-commands.ts
@@ -1,4 +1,4 @@
-import { Command } from './icommand';
+import { Command } from '../commands/icommand';
 import * as joint from 'jointjs';
 import { g } from 'jointjs';
 import { Graph } from "../graph/model/graph";

--- a/client/src/app/architecture/node-commands.ts
+++ b/client/src/app/architecture/node-commands.ts
@@ -1,10 +1,10 @@
-import { Command } from '../commands/icommand';
+import { SequentiableCommand } from '../commands/icommand';
 import * as joint from 'jointjs';
 import { g } from 'jointjs';
 import { Graph } from "../graph/model/graph";
 
 
-export abstract class NodeCommand<T extends joint.shapes.microtosca.Node> implements Command {
+export abstract class NodeCommand<T extends joint.shapes.microtosca.Node> extends SequentiableCommand {
     
     abstract execute();
     abstract unexecute();
@@ -20,18 +20,20 @@ export abstract class NodeCommand<T extends joint.shapes.microtosca.Node> implem
     }
 
     constructor(node?: T) {
+        super();
         this.node = node;
     }
 
-    then(next: NodeCommand<T>): NodeCommand<T> {
+    then(next: NodeCommand<joint.shapes.microtosca.Node>): NodeCommand<joint.shapes.microtosca.Node> {
         let action = () => {this.execute()};
         let revert = () => {this.unexecute()};
         let getNode = () => { return this.getNode() };
-        return new class extends NodeCommand<T> {
+        return new class extends NodeCommand<joint.shapes.microtosca.Node> {
             execute() {
                 action();
                 let node = getNode();
-                next.setNode(node);
+                if(next.setNode)
+                    next.setNode(node);
                 next.execute();
             }
             unexecute() {
@@ -125,7 +127,7 @@ export class AddMessageRouterCommand extends NodeGeneratorCommand<joint.shapes.m
     }
 }
 
-export class RemoveNodeCommand implements Command {
+export class RemoveNodeCommand extends SequentiableCommand {
 
     graph: Graph;
     node: joint.shapes.microtosca.Root;
@@ -136,6 +138,7 @@ export class RemoveNodeCommand implements Command {
     outcomingNodes: joint.shapes.microtosca.Root[];
 
     constructor(graph: Graph, node: joint.shapes.microtosca.Root) {
+        super();
         this.graph = graph;
         this.node = node;
         // TODO get the team of the node in order to restore in into the team when redo
@@ -167,7 +170,7 @@ export class RemoveNodeCommand implements Command {
     }
 }
 
-export class RemoveServiceCommand implements Command {
+export class RemoveServiceCommand extends SequentiableCommand {
 
     graph: Graph;
     node_name: string;
@@ -178,6 +181,7 @@ export class RemoveServiceCommand implements Command {
     outcoming_links = new Map();
 
     constructor(graph: Graph, node_name: string) {
+        super();
         this.graph = graph;
         this.node_name = node_name;
       
@@ -220,7 +224,7 @@ export class RemoveServiceCommand implements Command {
     }
 }
 
-export class RemoveDatastoreCommand implements Command {
+export class RemoveDatastoreCommand extends SequentiableCommand {
 
     graph: Graph;
     node_name: string;
@@ -230,6 +234,7 @@ export class RemoveDatastoreCommand implements Command {
     incoming_links = new Map();
 
     constructor(graph: Graph, node_name: string) {
+        super();
         this.graph = graph;
         this.node_name = node_name;
       
@@ -262,7 +267,7 @@ export class RemoveDatastoreCommand implements Command {
     }
 }
 
-export class RemoveCommunicationPatternCommand implements Command {
+export class RemoveCommunicationPatternCommand extends SequentiableCommand {
 
     graph: Graph;
     node_name: string;
@@ -274,6 +279,7 @@ export class RemoveCommunicationPatternCommand implements Command {
 
 
     constructor(graph: Graph, node_name: string) {
+        super();
         this.graph = graph;
         this.node_name = node_name;
       

--- a/client/src/app/commands/icommand.ts
+++ b/client/src/app/commands/icommand.ts
@@ -3,6 +3,48 @@ export interface Command {
     unexecute: () => void
 }
 
+export abstract class ElementCommand<T extends joint.shapes.microtosca.Root> implements Command {
+    
+    abstract execute();
+    abstract unexecute();
+
+    protected element: T;
+
+    set(element: T) {
+        this.element = element;
+    }
+
+    get(): T {
+        return this.element;
+    }
+
+    constructor(node?: T) {
+        this.element = node;
+    }
+
+    then<U extends Command>(next: U): Sequentiable<U> {
+        let action = () => {this.execute()};
+        let revert = () => {this.unexecute()};
+        let getNode = () => { return this.get() };
+
+        let newCommand = Sequentiable.of(next);
+
+        newCommand.execute = () => {
+            action();
+            let element = getNode();
+            if(next instanceof ElementCommand)
+                next.set(element);
+            next.execute();
+        }
+        newCommand.unexecute = () => {
+            next.unexecute();
+            revert();
+        }
+        return newCommand;
+    };
+
+}
+
 export class Sequentiable<T extends Command> implements Command {
 
     private constructor(private command: T) {}
@@ -18,14 +60,20 @@ export class Sequentiable<T extends Command> implements Command {
     }
 
     static of<T extends Command>(command: T): Sequentiable<T> {
+        if(command instanceof Sequentiable)
+            return new Sequentiable<T>(command.command);
         return new Sequentiable<T>(command);
     }
 
-    then<U extends Command>(next: U): Sequentiable<U> {
+    then<C extends Command>(next: (C | Sequentiable<C>)): Sequentiable<C> {
         let action = () => {this.execute()};
         let revert = () => {this.unexecute()};
 
-        let newCommand = Sequentiable.of(next);
+        let newCommand;
+        if(next instanceof Sequentiable)
+            newCommand = next;
+        else
+            newCommand = Sequentiable.of(next);
 
         newCommand.execute = () => {
             action();
@@ -35,6 +83,7 @@ export class Sequentiable<T extends Command> implements Command {
             next.unexecute();
             revert();
         }
+        
         return newCommand;
     };
 }

--- a/client/src/app/commands/icommand.ts
+++ b/client/src/app/commands/icommand.ts
@@ -4,3 +4,23 @@ export interface Command {
     unexecute: () => void
 }
 
+export abstract class SequentiableCommand implements Command {
+
+    abstract execute();
+    abstract unexecute();
+
+    then(next: Command): Command {
+        let action = () => {this.execute()};
+        let revert = () => {this.unexecute()};
+        return new class implements Command {
+            execute() {
+                action();
+                next.execute();
+            }
+            unexecute() {
+                next.unexecute();
+                revert();
+            }
+        };
+    }
+}

--- a/client/src/app/commands/icommand.ts
+++ b/client/src/app/commands/icommand.ts
@@ -1,26 +1,38 @@
-
 export interface Command {
     execute: () => void
     unexecute: () => void
 }
 
-export abstract class SequentiableCommand implements Command {
+export class Sequentiable<T extends Command> implements Command {
 
-    abstract execute();
-    abstract unexecute();
+    private constructor(private command: T) {}
 
-    then(next: Command): Command {
+    execute() {
+        this.command.execute();
+    }
+    
+    unexecute() {
+        this.command.unexecute();
+    }
+
+    static of<T extends Command>(command: T): Sequentiable<T> {
+        return new Sequentiable<T>(command);
+    }
+
+    then<U extends Command>(next: U): Sequentiable<U> {
         let action = () => {this.execute()};
         let revert = () => {this.unexecute()};
-        return new class implements Command {
-            execute() {
-                action();
-                next.execute();
-            }
-            unexecute() {
-                next.unexecute();
-                revert();
-            }
-        };
-    }
+
+        let newCommand = Sequentiable.of(next);
+
+        newCommand.execute = () => {
+            action();
+            next.execute();
+        }
+        newCommand.unexecute = () => {
+            next.unexecute();
+            revert();
+        }
+        return newCommand;
+    };
 }

--- a/client/src/app/commands/icommand.ts
+++ b/client/src/app/commands/icommand.ts
@@ -3,6 +3,36 @@ export interface Command {
     unexecute: () => void
 }
 
+export abstract class CompositeCommand implements Command {
+
+    private commands: Command[];
+
+    abstract getCommandsImplementation(...any): Command[];
+
+    constructor(...any) {
+        this.commands = this.getCommandsImplementation(...any);
+        console.debug("commands have been set in composite", this.commands);
+    }
+
+    execute() {
+        console.debug("executing commands", this.commands);
+        this.commands.forEach(command => command.execute());
+    }
+
+    unexecute() {
+        this.commands.slice().reverse().forEach(command => command.unexecute());
+    }
+
+    static of(commands: Command[]): CompositeCommand {
+        return new class extends CompositeCommand {
+            getCommandsImplementation(...any: any[]): Command[] {
+                return commands;
+            }
+        }
+    }
+
+}
+
 export abstract class ElementCommand<T extends joint.shapes.microtosca.Root> implements Command {
     
     abstract execute();
@@ -18,8 +48,8 @@ export abstract class ElementCommand<T extends joint.shapes.microtosca.Root> imp
         return this.element;
     }
 
-    constructor(node?: T) {
-        this.element = node;
+    constructor(element?: T) {
+        this.element = element;
     }
 
     then<U extends Command>(next: U): Sequentiable<U> {

--- a/client/src/app/commands/icommand.ts
+++ b/client/src/app/commands/icommand.ts
@@ -8,10 +8,12 @@ export class Sequentiable<T extends Command> implements Command {
     private constructor(private command: T) {}
 
     execute() {
+        console.debug("executing", this.command);
         this.command.execute();
     }
     
     unexecute() {
+        console.debug("unexecuting", this.command);
         this.command.unexecute();
     }
 

--- a/client/src/app/commands/invoker.ts
+++ b/client/src/app/commands/invoker.ts
@@ -14,7 +14,7 @@ export class GraphInvoker {
     private invokeSubject: Subject<void> = new Subject<void>();
     private observableInvocation: Observable<void> = this.invokeSubject.asObservable();
 
-    constructor(private as: AnalyserService) {
+    constructor() {
         this.undoStack = [];
         this.redoStack = [];
     }
@@ -43,7 +43,7 @@ export class GraphInvoker {
         let command = this.redoStack.pop()
         command.execute();
         this.undoStack.push(command);
-
+        
         this.invokeSubject.next();
     }
 

--- a/client/src/app/editor/graph-editor.component.ts
+++ b/client/src/app/editor/graph-editor.component.ts
@@ -320,7 +320,7 @@ export class GraphEditorComponent {
                 }
             }
             // node clicked
-            if (graph.isNode(element)) {
+            else {
                 console.log("add link enabled?", this.toolSelection.isAddLinkEnabled());
                 console.log("hasSmells?", element.hasSmells());
                 console.log("contextmenu", this.contextMenu);

--- a/client/src/app/graph/model/graph.ts
+++ b/client/src/app/graph/model/graph.ts
@@ -203,7 +203,7 @@ export class Graph extends joint.dia.Graph {
         return new g.Point(centerX, centerY);
     }
 
-    addService(name: string, position?: g.Point, team?: joint.shapes.microtosca.SquadGroup): joint.shapes.microtosca.Service {
+    addService(name: string, position?: g.Point): joint.shapes.microtosca.Service {
         let service = new joint.shapes.microtosca.Service();
         service.setName(name);
         if(position) {
@@ -211,9 +211,6 @@ export class Graph extends joint.dia.Graph {
             service.position(center.x, center.y);
         }
         service.addTo(this);
-        if(team) {
-            team.addMember(service);
-        }
         return service;
     }
 
@@ -224,7 +221,7 @@ export class Graph extends joint.dia.Graph {
         return compute;
     }
 
-    addDatastore(name: string, position?: g.Point, team?: joint.shapes.microtosca.SquadGroup): joint.shapes.microtosca.Datastore {
+    addDatastore(name: string, position?: g.Point): joint.shapes.microtosca.Datastore {
         let database = new joint.shapes.microtosca.Datastore();
         database.resize(75, 100);
         if(position) {
@@ -234,13 +231,10 @@ export class Graph extends joint.dia.Graph {
         database.topRy('20%');
         database.setName(name);
         database.addTo(this);
-        if(team) {
-            team.addMember(database);
-        }
         return database;
     }
 
-    addCommunicationPattern(name: string, type: string, position?: g.Point, team?: joint.shapes.microtosca.SquadGroup): joint.shapes.microtosca.CommunicationPattern {
+    addCommunicationPattern(name: string, type: string, position?: g.Point): joint.shapes.microtosca.CommunicationPattern {
         let cp = new joint.shapes.microtosca.CommunicationPattern();
         console.log(cp);
         cp.setName(name);
@@ -250,9 +244,6 @@ export class Graph extends joint.dia.Graph {
             cp.position(center.x, center.y);
         }
         cp.addTo(this);
-        if(team) {
-            team.addMember(cp);
-        }
         return cp;
     }
 

--- a/client/src/app/graph/model/microtosca.ts
+++ b/client/src/app/graph/model/microtosca.ts
@@ -212,7 +212,7 @@ class MicrotoscaElementConfiguration {
             hasSmells: function ():  boolean {
                 return this.attributes.smells.length > 0;
             },
-            remove: function (smell: SmellObject): SmellObject {
+            removeSmell: function (smell: SmellObject): SmellObject {
                 let smells: SmellObject[] = this.attributes.smells;
                 let smellIndex = smells.indexOf(this.getSmell(smell.getName()));
                 return smells.splice(smellIndex, 1)[0];

--- a/client/src/app/refactoring/analyser.service.ts
+++ b/client/src/app/refactoring/analyser.service.ts
@@ -14,7 +14,7 @@ import { Smell } from '../graph/model/smell';
 import { SmellObject, GroupSmellObject, SingleLayerTeamsSmellObject } from './smell';
 import { SMELL_NAMES } from "./costants";
 
-import { IgnoreOnceRefactoring, IgnoreAlwaysRefactoring, Refactoring } from "./refactoring-command";
+import { IgnoreOnceRefactoring, IgnoreAlwaysRefactoring, Refactoring } from "./refactoring-commands";
 import { WobblyServiceInteractionSmellObject, SharedPersistencySmellObject, EndpointBasedServiceInteractionSmellObject, NoApiGatewaySmellObject, MultipleServicesInOneContainerSmellObject } from "./smell";
 import { CommunicationPattern } from "../graph/model/communicationpattern";
 import { RefactoringFactoryService } from './refactoring-factory.service';

--- a/client/src/app/refactoring/costants.ts
+++ b/client/src/app/refactoring/costants.ts
@@ -14,10 +14,11 @@ export enum REFACTORING_NAMES {
     REFACTORING_ADD_CIRCUIT_BREAKER = 'Add-circuit-breaker',
     REFACTORING_USE_TIMEOUT = "Use-timeout",
     REFACTORING_MERGE_SERVICES = "Merge-service",
-    REFACTORING_SPLIT_DATABASE = "Split-database",
+    REFACTORING_SPLIT_DATASTORE = "Split-Datastore",
     REFACTORING_ADD_DATA_MANAGER = "Add-data-manager",
     REFACTORING_ADD_API_GATEWAY = "Add-api-gateway",
     REFACTORING_ADD_TEAM_DATA_MANAGER = "Add-data-team-data-manager",
-    REFACTORING_CHANGE_DATABASE_OWENRSHIP = "Change-database-ownership",
-    REFACTORING_CHANGE_SERVICE_OWENRSHIP = "Change-service-ownership"
+    REFACTORING_CHANGE_DATASTORE_OWENRSHIP = "Change-Datastore-ownership",
+    REFACTORING_CHANGE_SERVICE_OWENRSHIP = "Change-service-ownership",
+    REFACTORING_MERGE_TEAMS = "Merge-teams"
 }

--- a/client/src/app/refactoring/dialog-analysis/dialog-analysis.component.ts
+++ b/client/src/app/refactoring/dialog-analysis/dialog-analysis.component.ts
@@ -27,7 +27,7 @@ export class DialogAnalysisComponent implements OnInit {
   containerOrchestrators: Orchestrator[] = [];
   selectedOrchestrator: Orchestrator;
 
-  constructor(private gs: GraphService, private as: AnalyserService, private messageService: MessageService, public ref: DynamicDialogRef, public config: DynamicDialogConfig) { //public ref: DynamicDialogRef, public config: DynamicDialogConfig) {
+  constructor(private as: AnalyserService, public ref: DynamicDialogRef, public config: DynamicDialogConfig) {
 
     this.containerOrchestrators = [
       { id: 1, name: 'Custom', img: "general.jpeg", resolvedSmells: [] },

--- a/client/src/app/refactoring/refactoring-commands.ts
+++ b/client/src/app/refactoring/refactoring-commands.ts
@@ -607,7 +607,7 @@ export class SplitTeamsSharedDatastoreRefactoring extends RefactoringCommand {
     }
 
     getDescription() {
-        return "Split datastores basing on services.";
+        return "Replace the interactions to external datastores with an internal datastore split.";
     }
 
 }

--- a/client/src/app/refactoring/refactoring-factory.service.ts
+++ b/client/src/app/refactoring/refactoring-factory.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import { GroupSmellObject, SmellObject } from './smell';
-import { AddApiGatewayRefactoring, AddCircuitBreakerRefactoring, AddDataManagerIntoTeamRefactoring, AddDataManagerRefactoring, AddMessageBrokerRefactoring, AddMessageRouterRefactoring, AddServiceDiscoveryRefactoring, MergeServicesRefactoring, MoveDatastoreIntoTeamRefactoring, MoveServiceIntoTeamRefactoring, Refactoring, SplitDatastoreRefactoring, UseTimeoutRefactoring } from './refactoring-command';
 import { REFACTORING_NAMES } from './costants';
 import { GraphService } from '../graph/graph.service';
+import { AddApiGatewayRefactoring, AddCircuitBreakerRefactoring, AddDataManagerRefactoring, AddMessageBrokerRefactoring, AddMessageRouterRefactoring, AddServiceDiscoveryRefactoring, AddTeamDataManagerRefactoring, MergeServicesRefactoring, ChangeDatastoreOwnershipRefactoring, ChangeServiceOwnershipRefactoring, Refactoring, SplitDatastoreRefactoring, UseTimeoutRefactoring } from './refactoring-commands';
 
 @Injectable({
   providedIn: 'root'
@@ -43,7 +43,7 @@ export class RefactoringFactoryService {
       case REFACTORING_NAMES.REFACTORING_MERGE_SERVICES:
         return new MergeServicesRefactoring(this.gs.getGraph(), smell);
       
-      case REFACTORING_NAMES.REFACTORING_SPLIT_DATABASE:
+      case REFACTORING_NAMES.REFACTORING_SPLIT_DATASTORE:
         return new SplitDatastoreRefactoring(this.gs.getGraph(), smell);
       
       case REFACTORING_NAMES.REFACTORING_ADD_DATA_MANAGER:
@@ -58,14 +58,14 @@ export class RefactoringFactoryService {
       case REFACTORING_NAMES.REFACTORING_ADD_API_GATEWAY:
         return new AddApiGatewayRefactoring(this.gs.getGraph(), smell);
 
-      case REFACTORING_NAMES.REFACTORING_CHANGE_DATABASE_OWENRSHIP:
-        return new MoveDatastoreIntoTeamRefactoring(this.gs.getGraph(), smell);
+      case REFACTORING_NAMES.REFACTORING_CHANGE_DATASTORE_OWENRSHIP:
+        return new ChangeDatastoreOwnershipRefactoring(this.gs.getGraph(), smell);
 
-        case REFACTORING_NAMES.REFACTORING_CHANGE_SERVICE_OWENRSHIP:
-        return new MoveServiceIntoTeamRefactoring(this.gs.getGraph(), smell);
+      case REFACTORING_NAMES.REFACTORING_CHANGE_SERVICE_OWENRSHIP:
+        return new ChangeServiceOwnershipRefactoring(this.gs.getGraph(), smell);
 
       case REFACTORING_NAMES.REFACTORING_ADD_TEAM_DATA_MANAGER:
-        return new AddDataManagerIntoTeamRefactoring(this.gs.getGraph(), smell);
+        return new AddTeamDataManagerRefactoring(this.gs.getGraph(), smell);
 
     }
   }

--- a/client/src/app/refactoring/refactoring-factory.service.ts
+++ b/client/src/app/refactoring/refactoring-factory.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { GroupSmellObject, SmellObject } from './smell';
 import { REFACTORING_NAMES } from './costants';
 import { GraphService } from '../graph/graph.service';
-import { AddApiGatewayRefactoring, AddCircuitBreakerRefactoring, AddDataManagerRefactoring, AddMessageBrokerRefactoring, AddMessageRouterRefactoring, AddServiceDiscoveryRefactoring, SplitTeamsSharedDatastoreRefactoring, MergeServicesRefactoring, ChangeDatastoreOwnershipRefactoring, ChangeServiceOwnershipRefactoring, Refactoring, SplitDatastoreRefactoring, UseTimeoutRefactoring } from './refactoring-commands';
+import { AddApiGatewayRefactoring, AddCircuitBreakerRefactoring, AddDataManagerRefactoring, AddMessageBrokerRefactoring, AddMessageRouterRefactoring, AddServiceDiscoveryRefactoring, SplitTeamsSharedDatastoreRefactoring, MergeServicesRefactoring, ChangeDatastoreOwnershipRefactoring, ChangeServiceOwnershipRefactoring, Refactoring, SplitDatastoreRefactoring, UseTimeoutRefactoring, MergeTeamsRefactoring } from './refactoring-commands';
 
 @Injectable({
   providedIn: 'root'
@@ -66,6 +66,9 @@ export class RefactoringFactoryService {
 
       case REFACTORING_NAMES.REFACTORING_SPLIT_DATASTORE:
         return new SplitTeamsSharedDatastoreRefactoring(this.gs.getGraph(), smell);
+
+      case REFACTORING_NAMES.REFACTORING_MERGE_TEAMS:
+        return new MergeTeamsRefactoring(this.gs.getGraph(), smell);
 
     }
   }

--- a/client/src/app/refactoring/refactoring-factory.service.ts
+++ b/client/src/app/refactoring/refactoring-factory.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { GroupSmellObject, SmellObject } from './smell';
 import { REFACTORING_NAMES } from './costants';
 import { GraphService } from '../graph/graph.service';
-import { AddApiGatewayRefactoring, AddCircuitBreakerRefactoring, AddDataManagerRefactoring, AddMessageBrokerRefactoring, AddMessageRouterRefactoring, AddServiceDiscoveryRefactoring, AddTeamDataManagerRefactoring, MergeServicesRefactoring, ChangeDatastoreOwnershipRefactoring, ChangeServiceOwnershipRefactoring, Refactoring, SplitDatastoreRefactoring, UseTimeoutRefactoring } from './refactoring-commands';
+import { AddApiGatewayRefactoring, AddCircuitBreakerRefactoring, AddDataManagerRefactoring, AddMessageBrokerRefactoring, AddMessageRouterRefactoring, AddServiceDiscoveryRefactoring, SplitTeamsSharedDatastoreRefactoring, MergeServicesRefactoring, ChangeDatastoreOwnershipRefactoring, ChangeServiceOwnershipRefactoring, Refactoring, SplitDatastoreRefactoring, UseTimeoutRefactoring } from './refactoring-commands';
 
 @Injectable({
   providedIn: 'root'
@@ -64,8 +64,8 @@ export class RefactoringFactoryService {
       case REFACTORING_NAMES.REFACTORING_CHANGE_SERVICE_OWENRSHIP:
         return new ChangeServiceOwnershipRefactoring(this.gs.getGraph(), smell);
 
-      case REFACTORING_NAMES.REFACTORING_ADD_TEAM_DATA_MANAGER:
-        return new AddTeamDataManagerRefactoring(this.gs.getGraph(), smell);
+      case REFACTORING_NAMES.REFACTORING_SPLIT_DATASTORE:
+        return new SplitTeamsSharedDatastoreRefactoring(this.gs.getGraph(), smell);
 
     }
   }

--- a/client/src/app/refactoring/smell.ts
+++ b/client/src/app/refactoring/smell.ts
@@ -1,5 +1,5 @@
 import * as joint from 'jointjs';
-import { Refactoring } from './refactoring-command';
+import { Refactoring } from './refactoring-commands';
 
 export class SmellObject {
 
@@ -48,7 +48,7 @@ export class SmellObject {
             let source = <joint.shapes.microtosca.Root>link.getSourceElement();
             let target = <joint.shapes.microtosca.Root>link.getTargetElement();
 
-            descr += `Interaction from  ${source.getName()} to ${target.getName()} \n`;
+            descr += `Interaction from ${source.getName()} to ${target.getName()}.\n`;
         })
         return descr;
     }
@@ -109,7 +109,7 @@ export class GroupSmellObject {
             let source = <joint.shapes.microtosca.Root>link.getSourceElement();
             let target = <joint.shapes.microtosca.Root>link.getTargetElement();
 
-            descr += `Interaction from  ${source.getName()} to ${target.getName()} \n`;
+            descr += `Interaction from ${source.getName()} to ${target.getName()}.\n`;
         })
         return descr;
     }
@@ -144,7 +144,7 @@ export class EndpointBasedServiceInteractionSmellObject extends SmellObject {
             let source = <joint.shapes.microtosca.Root>link.getSourceElement();
             let target = <joint.shapes.microtosca.Root>link.getTargetElement();
 
-            descr += `Interaction from  ${source.getName()} to ${target.getName()} \n`;
+            descr += `Interaction from ${source.getName()} to ${target.getName()}.\n`;
         })
         return descr;
     }
@@ -152,25 +152,31 @@ export class EndpointBasedServiceInteractionSmellObject extends SmellObject {
 
 export class SharedPersistencySmellObject extends SmellObject {
     constructor() {
-        super("SharedPersistencySmell");
+        super("Shared persistency");
     }
 }
 export class WobblyServiceInteractionSmellObject extends SmellObject {
 
     constructor() {
-        super("WobblyServiceInteractonSmell");
+        super("Wobbly service interaction");
     }
 }
 
 export class SingleLayerTeamsSmellObject extends GroupSmellObject {
 
     constructor(group:joint.shapes.microtosca.SquadGroup) {
-        super("SingleLayerTeamsSmell", group);
+        super("Single-layer teams", group);
+    }
+
+    getDescription(): string {
+        let services = new Set<joint.shapes.microtosca.Root>();
+        this.getLinkBasedCauses().forEach(link => { services.add(<joint.shapes.microtosca.Root>link.getSourceElement()) });
+        return `${this.group.getName()} may lack some skills since there are services that access data owned by other teams: ${Array.from(services).map((service) => service.getName()).join(", ")}.`;
     }
 }
 
 export class MultipleServicesInOneContainerSmellObject extends SmellObject {
     constructor() {
-        super("MultipleServicesInOneContainerSmell")
+        super("Multiple services in one container")
     }
 }

--- a/client/src/app/refactoring/subtoolbar-refactoring/subtoolbar-refactoring.component.ts
+++ b/client/src/app/refactoring/subtoolbar-refactoring/subtoolbar-refactoring.component.ts
@@ -65,12 +65,13 @@ export class SubtoolbarRefactoringComponent {
                                     .subscribe(data => {
                                         this.as.showSmells();
                                         this.smellsNumber = this.as.getNumSmells()
-                                        this.messageService.add({ severity: 'success', summary: "Analysis performed correctly", detail: `Found ${this.smellsNumber} smells` });
+                                        //this.messageService.add({ severity: 'success', summary: "Analysis performed correctly", detail: `Found ${this.smellsNumber} smells` });
                                     });
                             });
                 };
                 this.invokerSubscription = this.commands.subscribe(analyseGraph);
                 analyseGraph();
+                this.messageService.add({ severity: 'success', summary: "Smells analysis started", detail: `Smells analysis is now active.` });
             } else {
                 this.monitorToggled = false;
             }
@@ -81,6 +82,7 @@ export class SubtoolbarRefactoringComponent {
         console.log("stopMonitoring");
         this.invokerSubscription.unsubscribe();
         this.as.clearSmells();
+        this.messageService.add({ severity: 'success', summary: "Smells analysis stopped", detail: `Smells analysis is not active anymore.` });
     }
 
 }

--- a/client/src/app/refactoring/subtoolbar-refactoring/subtoolbar-refactoring.component.ts
+++ b/client/src/app/refactoring/subtoolbar-refactoring/subtoolbar-refactoring.component.ts
@@ -58,6 +58,7 @@ export class SubtoolbarRefactoringComponent {
                 }
 
                 let analyseGraph = () => {
+                    console.debug("analysing...")
                     this.gs.uploadGraph(this.options.team)
                             .subscribe(data => {
                                 console.log("uploadGraph response", data);

--- a/client/src/app/teams/team-commands.ts
+++ b/client/src/app/teams/team-commands.ts
@@ -1,6 +1,6 @@
-import { Command } from './icommand';
+import { Command } from '../commands/icommand';
 import { Graph } from "../graph/model/graph";
-import { NodeCommand } from './node-commands';
+import { NodeCommand } from '../architecture/node-commands';
 
 
 export class AddTeamGroupCommand implements Command {
@@ -59,10 +59,7 @@ export class RemoveMemberFromTeamGroupCommand extends NodeCommand<joint.shapes.m
         this.team.addMember(this.node);
         this.team.fitEmbeds({ padding: Graph.TEAM_PADDING });
     }
-
-    setTeam(team: joint.shapes.microtosca.SquadGroup) {
-        this.team = team;
-    }
+    
 }
 
 export class RemoveTeamGroupCommand implements Command {

--- a/client/src/app/teams/team-commands.ts
+++ b/client/src/app/teams/team-commands.ts
@@ -1,14 +1,15 @@
-import { Command } from '../commands/icommand';
+import { SequentiableCommand } from '../commands/icommand';
 import { Graph } from "../graph/model/graph";
 import { NodeCommand } from '../architecture/node-commands';
 
 
-export class AddTeamGroupCommand implements Command {
+export class AddTeamGroupCommand extends SequentiableCommand {
 
     graph: Graph;
     team_name: string;
 
     constructor(graph: Graph, team_name: string) {
+        super();
         this.graph = graph;
         this.team_name = team_name;
     }
@@ -62,14 +63,16 @@ export class RemoveMemberFromTeamGroupCommand extends NodeCommand<joint.shapes.m
     
 }
 
-export class RemoveTeamGroupCommand implements Command {
+export class RemoveTeamGroupCommand extends SequentiableCommand {
 
     removeMemberCommands: RemoveMemberFromTeamGroupCommand[];
 
     constructor(
         private graph: Graph,
         private team: joint.shapes.microtosca.SquadGroup
-    ) {}
+    ) {
+        super();
+    }
 
     execute() {
         this.removeMemberCommands = [];

--- a/client/src/app/teams/team-commands.ts
+++ b/client/src/app/teams/team-commands.ts
@@ -1,25 +1,28 @@
-import { Command } from '../commands/icommand';
+import { Command, ElementCommand, Sequentiable } from '../commands/icommand';
 import { Graph } from "../graph/model/graph";
 import { NodeCommand } from '../architecture/node-commands';
 
+export abstract class TeamCommand extends ElementCommand<joint.shapes.microtosca.SquadGroup> {}
 
-export class AddTeamGroupCommand implements Command {
+export class AddTeamGroupCommand extends TeamCommand {
 
     graph: Graph;
     team_name: string;
 
     constructor(graph: Graph, team_name: string) {
+        super();
         this.graph = graph;
         this.team_name = team_name;
     }
 
     execute() {
-        this.graph.addTeamGroup(this.team_name);
+        this.set(this.graph.addTeamGroup(this.team_name));
     }
 
     unexecute() {
-        let team = this.graph.getGroup(this.team_name);
-        team.remove();
+        this.get().remove();
+        //let team = this.graph.getGroup(this.team_name);
+        //team.remove();
     }
 
 }
@@ -28,16 +31,16 @@ export class AddMemberToTeamGroupCommand extends NodeCommand<joint.shapes.microt
 
     constructor(private team: joint.shapes.microtosca.SquadGroup, node?: joint.shapes.microtosca.Node) {
         super();
-        this.node = node;
+        this.set(node);
     }
 
     execute() {
-        this.team.addMember(this.node);
+        this.team.addMember(this.get());
         this.team.fitEmbeds({ padding: Graph.TEAM_PADDING });
     }
 
     unexecute() {
-        this.team.removeMember(this.node);
+        this.team.removeMember(this.get());
         this.team.fitEmbeds({ padding: Graph.TEAM_PADDING });
     }
 
@@ -47,16 +50,16 @@ export class RemoveMemberFromTeamGroupCommand extends NodeCommand<joint.shapes.m
 
     constructor(private team: joint.shapes.microtosca.SquadGroup, node?: joint.shapes.microtosca.Node) {
         super();
-        this.node = node;
+        this.set(node);
     }
 
     execute() {
-        this.team.removeMember(this.node);
+        this.team.removeMember(this.get());
         this.team.fitEmbeds({ padding: Graph.TEAM_PADDING });
     }
 
     unexecute() {
-        this.team.addMember(this.node);
+        this.team.addMember(this.get());
         this.team.fitEmbeds({ padding: Graph.TEAM_PADDING });
     }
     
@@ -85,4 +88,51 @@ export class RemoveTeamGroupCommand implements Command {
         this.graph.addCell(this.team);
         this.removeMemberCommands.forEach((command) => command.unexecute());
     }
+}
+
+export class MergeTeamsCommand implements Command {
+
+    newTeamName: string;
+    team: joint.shapes.microtosca.SquadGroup;
+    teams: joint.shapes.microtosca.SquadGroup[];
+
+    command;
+
+    constructor(private graph: Graph, newTeamName: string, team: joint.shapes.microtosca.SquadGroup, ...teams: joint.shapes.microtosca.SquadGroup[]) {
+        this.newTeamName = newTeamName;
+        this.team = team;
+        this.teams = teams;
+        this.command = this.getCommandImplementation()
+    }
+
+    getCommandImplementation() {
+        let removeTeamsCommand = this.teams.map((team) => Sequentiable.of(new RemoveTeamGroupCommand(this.graph, team)))
+                                            .reduce(((cmd, current) => cmd.then(current)), Sequentiable.of(new RemoveTeamGroupCommand(this.graph, this.team)));
+        let members = this.teams.flatMap((t) => t.getMembers());
+        let createTeamThenAddMembers = new AddTeamGroupCommand(this.graph, this.newTeamName).then(new class extends TeamCommand {
+            addMemberCmds: Command[];
+            execute() {
+                let team = this.get();
+                this.addMemberCmds = members.map((n) => new AddMemberToTeamGroupCommand(team, n));
+                this.addMemberCmds.forEach((cmd) => {
+                    cmd.execute();
+                });
+            }
+            unexecute() {
+                this.addMemberCmds.forEach((cmd) => {
+                    cmd.unexecute();
+                })
+            }
+        });
+        return removeTeamsCommand.then(createTeamThenAddMembers);
+    }
+
+    execute() {
+        this.command.execute();
+    }
+
+    unexecute() {
+        this.command.unexecute();
+    }
+
 }

--- a/client/src/app/teams/team-commands.ts
+++ b/client/src/app/teams/team-commands.ts
@@ -1,15 +1,14 @@
-import { SequentiableCommand } from '../commands/icommand';
+import { Command } from '../commands/icommand';
 import { Graph } from "../graph/model/graph";
 import { NodeCommand } from '../architecture/node-commands';
 
 
-export class AddTeamGroupCommand extends SequentiableCommand {
+export class AddTeamGroupCommand implements Command {
 
     graph: Graph;
     team_name: string;
 
     constructor(graph: Graph, team_name: string) {
-        super();
         this.graph = graph;
         this.team_name = team_name;
     }
@@ -63,16 +62,14 @@ export class RemoveMemberFromTeamGroupCommand extends NodeCommand<joint.shapes.m
     
 }
 
-export class RemoveTeamGroupCommand extends SequentiableCommand {
+export class RemoveTeamGroupCommand implements Command {
 
     removeMemberCommands: RemoveMemberFromTeamGroupCommand[];
 
     constructor(
         private graph: Graph,
         private team: joint.shapes.microtosca.SquadGroup
-    ) {
-        super();
-    }
+    ) {}
 
     execute() {
         this.removeMemberCommands = [];

--- a/client/src/app/teams/team-editing/team-editing.service.ts
+++ b/client/src/app/teams/team-editing/team-editing.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { MessageService } from 'primeng/api';
 import { Command } from 'src/app/commands/icommand';
 import { GraphInvoker } from 'src/app/commands/invoker';
-import { AddMemberToTeamGroupCommand, AddTeamGroupCommand, RemoveMemberFromTeamGroupCommand, RemoveTeamGroupCommand } from 'src/app/commands/team-commands';
+import { AddMemberToTeamGroupCommand, AddTeamGroupCommand, RemoveMemberFromTeamGroupCommand, RemoveTeamGroupCommand } from '../team-commands';
 import { GraphService } from 'src/app/graph/graph.service';
 import { Graph } from 'src/app/graph/model/graph';
 import { TeamsService } from '../teams.service';

--- a/client/src/tsconfig.app.json
+++ b/client/src/tsconfig.app.json
@@ -5,7 +5,11 @@
     "types": [],
     "paths": {      
       "yfiles/*": ["../../../../lib/es6-modules/yfiles/*"]
-    }
+    },
+    "lib": [
+      "ES2022",
+      "dom"
+    ]
   },
   "include": [
     "**/*.ts",


### PR DESCRIPTION
### New command classes
- Composite Commands
- Sequentiable
- AddManyMembersToTeamCommand
- MergeTeamsCommand


### SingleLayerTeamSmell

${this.group.getName()} may lack some skills because there are services that access data owned by other teams: ${Array.from(services).map((service) => service.getName()).join(", ")}.

**REFACTORING_SPLIT_DATASTORE**
Replace the interactions to external datastores with an internal datastore split.

**REFACTORING_CHANGE_DATABASE_OWENRSHIP**
Move all involved datastores under ${this.team.getName()}'s responsibility.

**REFACTORING_CHANGE_SERVICE_OWENRSHIP (c’era già)**
Move involved services out of ${this.team.getName()}'s responsibility. Datastore's team is chosen when possible.

**REFACTORING_MERGE_TEAMS**
Merge the teams owning the services and the datastores.